### PR TITLE
Add cache for produced preview images

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,6 +38,8 @@ For a multiple-page PDF, the first page is shown by default. You can specify the
 [[./docs/report.pdf]]
 #+END_SRC
 
+=org-inline-pdf.el= saves preview images in a temporary directory by default, which is removed on Emacs shutdown. To make images persist between Emacs sessions, you can change the variable =org-inline-pdf-cache-directory=.
+
 *** Inline PDF in exported HTML file
 
 This package also makes Org's HTML exporter ox-html to embed linked PDF files as images using =img= tag. Note that inline PDF using =img= tag is not standard and will be rendered only in particular browsers.  Safari.app is only the one I know.


### PR DESCRIPTION
Hi, I would like to avoid generating the same image each time the pdf is previewed. The conversion costs some time when I open org files containing many pdfs. This patch adds cache for preview images, and the conversion only occurs when there is no cache or the cache is outdated.